### PR TITLE
Fixed httpd error(Configuration error: No MPM loaded)

### DIFF
--- a/httpd.conf
+++ b/httpd.conf
@@ -63,6 +63,7 @@ Listen 80
 # Example:
 # LoadModule foo_module modules/mod_foo.so
 #
+LoadModule mpm_event_module modules/mod_mpm_event.so
 LoadModule authn_file_module modules/mod_authn_file.so
 #LoadModule authn_dbm_module modules/mod_authn_dbm.so
 #LoadModule authn_anon_module modules/mod_authn_anon.so


### PR DESCRIPTION
The current httpd error was the result of a latest update on the httpd code, see https://github.com/docker-library/httpd/pull/87. 
The solution was to add `LoadModule mpm_event_module modules/mod_mpm_event.so` into `httpd.conf` 